### PR TITLE
UPDATE missing configuration steps for hms-push library

### DIFF
--- a/react-native-hms-push/README.md
+++ b/react-native-hms-push/README.md
@@ -196,6 +196,8 @@ demo-app
 - Configure build dependencies.
 
 ```groovy
+apply plugin: "com.huawei.agconnect" // <-- Add this line at beginning of file
+
 buildscript {
   ...
   dependencies {
@@ -203,6 +205,7 @@ buildscript {
     * <Other dependencies>
     */
     implementation project(":react-native-hms-push")    
+    implementation 'com.huawei.agconnect:agconnect-core:1.4.1.300'
     ...    
   }
 }


### PR DESCRIPTION
Added missing "com.huawei.agconnect" configuration in android/app/gradle for push notification. Else the hmsPushInstanceId.getToken("") method will always return Error code 907135000

[getToken] Error/Exception: {"nativeStackAndroid":[],"userInfo":null,"message":"907135000: arguments invalid","code":"907122045"}

despite of having all correct appID, package parameters and latest HMS Core App.

Adding these missing configuration resolves the issues