### PR TITLE
Prevent NPE on react-native-hms-push

### DIFF
--- a/react-native-hms-push/android/src/main/java/com/huawei/hms/rn/push/remote/HmsPushMessaging.java
+++ b/react-native-hms-push/android/src/main/java/com/huawei/hms/rn/push/remote/HmsPushMessaging.java
@@ -263,8 +263,11 @@ public class HmsPushMessaging extends ReactContextBaseJavaModule implements Acti
 
     @Override
     public void onNewIntent(Intent intent) {
-
-        context.getCurrentActivity().setIntent(intent);
+        Activity currentActivity = context.getCurrentActivity();
+        // this should never happened, but is nullable by contract
+        if(currentActivity != null){
+            currentActivity.setIntent(intent);
+        }
     }
 
     @Override

--- a/react-native-hms-push/package.json
+++ b/react-native-hms-push/package.json
@@ -2,7 +2,7 @@
   "name": "@hmscore/react-native-hms-push",
   "title": "React Native HMS Push Kit",
   "description": "React Native HMS Push Kit",
-  "version": "5.0.2-301Fbk",
+  "version": "5.0.2-301",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/react-native-hms-push/package.json
+++ b/react-native-hms-push/package.json
@@ -2,7 +2,7 @@
   "name": "@hmscore/react-native-hms-push",
   "title": "React Native HMS Push Kit",
   "description": "React Native HMS Push Kit",
-  "version": "5.0.2-301",
+  "version": "5.0.2-301Fbk",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
in react-native-hms-push, HmsPushMessaging use the context.getCurrentActivity() method. This method is @Nullable by contract, but a not null check is missing. 

Added a null check to prevent possible NullPointerException