### PR TITLE
FIX add deprecated-react-native-prop-types library for react-native-hms-map

### DIFF
--- a/react-native-hms-map/package.json
+++ b/react-native-hms-map/package.json
@@ -31,7 +31,8 @@
   "peerDependencies": {
     "prop-types": "^15.7.2",
     "react": ">=16.6.0",
-    "react-native": ">=0.60.0 <1.0.x"
+    "react-native": ">=0.60.0 <1.0.x",
+    "deprecated-react-native-prop-types": "2.3.0"
   },
   "devDependencies": {
     "react": "16.6.0",

--- a/react-native-hms-map/src/CircleView.js
+++ b/react-native-hms-map/src/CircleView.js
@@ -14,9 +14,18 @@
     limitations under the License.
 */
 
-import { exact, oneOf, number, arrayOf, bool, func, oneOfType } from "prop-types";
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
+import {
+  arrayOf,
+  bool,
+  exact,
+  func,
+  number,
+  oneOf,
+  oneOfType,
+} from "prop-types";
 import React, { Component } from "react";
-import { requireNativeComponent, ViewPropTypes } from "react-native";
+import { requireNativeComponent } from "react-native";
 import { PatternItemTypes } from "./constants";
 
 class HMSCircleView extends Component {
@@ -46,16 +55,13 @@ HMSCircleView.propTypes = {
     exact({
       type: oneOf(Object.values(PatternItemTypes)).isRequired,
       length: number,
-    }),
+    })
   ),
   visible: bool,
   zIndex: number,
   onClick: func,
 };
 
-const RNHMSCircleView = requireNativeComponent(
-  "HMSCircleView",
-  HMSCircleView,
-);
+const RNHMSCircleView = requireNativeComponent("HMSCircleView", HMSCircleView);
 
 export default HMSCircleView;

--- a/react-native-hms-map/src/GroundOverlayView.js
+++ b/react-native-hms-map/src/GroundOverlayView.js
@@ -14,19 +14,19 @@
     limitations under the License.
 */
 
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
 import {
-  string,
-  exact,
-  number,
-  oneOfType,
-  bool,
-  func,
   array,
   arrayOf,
+  bool,
+  exact,
+  func,
+  number,
+  oneOfType,
+  string,
 } from "prop-types";
 import React, { Component } from "react";
-import { requireNativeComponent, ViewPropTypes } from "react-native";
-
+import { requireNativeComponent } from "react-native";
 class HMSGroundOverlayView extends Component {
   constructor() {
     super();
@@ -62,7 +62,7 @@ HMSGroundOverlayView.propTypes = {
       exact({
         latitude: number.isRequired,
         longitude: number.isRequired,
-      }),
+      })
     ),
   ]).isRequired,
   anchor: array,
@@ -76,7 +76,7 @@ HMSGroundOverlayView.propTypes = {
 
 const RNHMSGroundOverlayView = requireNativeComponent(
   "HMSGroundOverlayView",
-  HMSGroundOverlayView,
+  HMSGroundOverlayView
 );
 
 export default HMSGroundOverlayView;

--- a/react-native-hms-map/src/InfoWindowView.js
+++ b/react-native-hms-map/src/InfoWindowView.js
@@ -14,9 +14,9 @@
     limitations under the License.
 */
 
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
 import React, { Component } from "react";
-import { requireNativeComponent, ViewPropTypes, View } from "react-native";
-
+import { requireNativeComponent } from "react-native";
 class HMSInfoWindowView extends Component {
   constructor() {
     super();
@@ -30,7 +30,8 @@ class HMSInfoWindowView extends Component {
         style={{
           ...this.props.style,
           alignSelf: "baseline",
-        }} />
+        }}
+      />
     );
   }
 }
@@ -43,7 +44,7 @@ HMSInfoWindowView.propTypes = {
 
 const RNHMSInfoWindowView = requireNativeComponent(
   "HMSInfoWindowView",
-  HMSInfoWindowView,
+  HMSInfoWindowView
 );
 
 export default HMSInfoWindowView;

--- a/react-native-hms-map/src/MapView.js
+++ b/react-native-hms-map/src/MapView.js
@@ -14,16 +14,15 @@
     limitations under the License.
 */
 
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
 import { func } from "prop-types";
 import React, { Component } from "react";
 import {
   findNodeHandle,
+  NativeModules,
   requireNativeComponent,
   UIManager,
-  NativeModules,
-  ViewPropTypes,
 } from "react-native";
-
 const { HMSMapViewModule } = NativeModules;
 
 class HMSMapView extends Component {
@@ -33,10 +32,8 @@ class HMSMapView extends Component {
       isMapReady: false,
     };
 
-    if (props.liteMode)
-      HMSMapViewModule.setLiteMod(props.liteMode);
-    else
-      HMSMapViewModule.setLiteMod(false);
+    if (props.liteMode) HMSMapViewModule.setLiteMod(props.liteMode);
+    else HMSMapViewModule.setLiteMod(false);
   }
 
   getHuaweiMapInfo = () => {
@@ -54,14 +51,14 @@ class HMSMapView extends Component {
   getPointFromCoordinate = (coordinate) => {
     return HMSMapViewModule.getPointFromCoordinate(
       findNodeHandle(this.mapView),
-      coordinate,
+      coordinate
     );
   };
 
   getCoordinateFromPoint = (point) => {
     return HMSMapViewModule.getCoordinateFromPoint(
       findNodeHandle(this.mapView),
-      point,
+      point
     );
   };
 
@@ -81,7 +78,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.clear,
-      null,
+      null
     );
   };
 
@@ -89,7 +86,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.takeSnapshot,
-      null,
+      null
     );
   };
 
@@ -98,7 +95,7 @@ class HMSMapView extends Component {
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands
         .resetMinMaxZoomPreference,
-      null,
+      null
     );
   };
 
@@ -106,7 +103,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.stopAnimation,
-      null,
+      null
     );
   };
 
@@ -114,7 +111,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.setCameraPosition,
-      [cameraPosition],
+      [cameraPosition]
     );
   };
 
@@ -122,7 +119,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.setCoordinates,
-      [latLng, zoom],
+      [latLng, zoom]
     );
   };
 
@@ -130,7 +127,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.setBounds,
-      [latLngBounds, padding, width, height],
+      [latLngBounds, padding, width, height]
     );
   };
 
@@ -138,7 +135,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.scrollBy,
-      [x, y],
+      [x, y]
     );
   };
 
@@ -146,7 +143,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.zoomBy,
-      [amount, focus],
+      [amount, focus]
     );
   };
 
@@ -154,7 +151,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.zoomTo,
-      [zoom],
+      [zoom]
     );
   };
 
@@ -162,7 +159,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.zoomIn,
-      null,
+      null
     );
   };
 
@@ -170,7 +167,7 @@ class HMSMapView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.mapView),
       UIManager.getViewManagerConfig("HMSMapView").Commands.zoomOut,
-      null,
+      null
     );
   };
 

--- a/react-native-hms-map/src/MarkerView.js
+++ b/react-native-hms-map/src/MarkerView.js
@@ -14,15 +14,14 @@
     limitations under the License.
 */
 
-import { string, exact, number, array, bool, func } from "prop-types";
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
+import { array, bool, exact, func, number, string } from "prop-types";
 import React, { Component } from "react";
 import {
   findNodeHandle,
   requireNativeComponent,
   UIManager,
-  ViewPropTypes,
 } from "react-native";
-
 class HMSMarkerView extends Component {
   constructor() {
     super();
@@ -32,7 +31,7 @@ class HMSMarkerView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.markerView),
       UIManager.getViewManagerConfig("HMSMarkerView").Commands.showInfoWindow,
-      null,
+      null
     );
   };
 
@@ -40,7 +39,7 @@ class HMSMarkerView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.markerView),
       UIManager.getViewManagerConfig("HMSMarkerView").Commands.hideInfoWindow,
-      null,
+      null
     );
   };
 
@@ -48,7 +47,7 @@ class HMSMarkerView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.markerView),
       UIManager.getViewManagerConfig("HMSMarkerView").Commands.startAnimation,
-      null,
+      null
     );
   };
 
@@ -56,7 +55,7 @@ class HMSMarkerView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.markerView),
       UIManager.getViewManagerConfig("HMSMarkerView").Commands.setAnimation,
-      [animation, defaultParams],
+      [animation, defaultParams]
     );
   };
 
@@ -64,7 +63,7 @@ class HMSMarkerView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.markerView),
       UIManager.getViewManagerConfig("HMSMarkerView").Commands.cleanAnimation,
-      null,
+      null
     );
   };
 
@@ -113,9 +112,6 @@ HMSMarkerView.propTypes = {
   onAnimationEnd: func,
 };
 
-const RNHMSMarkerView = requireNativeComponent(
-  "HMSMarkerView",
-  HMSMarkerView,
-);
+const RNHMSMarkerView = requireNativeComponent("HMSMarkerView", HMSMarkerView);
 
 export default HMSMarkerView;

--- a/react-native-hms-map/src/PolygonView.js
+++ b/react-native-hms-map/src/PolygonView.js
@@ -14,11 +14,19 @@
     limitations under the License.
 */
 
-import { exact, oneOf, number, arrayOf, bool, func, oneOfType } from "prop-types";
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
+import {
+  arrayOf,
+  bool,
+  exact,
+  func,
+  number,
+  oneOf,
+  oneOfType,
+} from "prop-types";
 import React, { Component } from "react";
-import { requireNativeComponent, ViewPropTypes } from "react-native";
+import { requireNativeComponent } from "react-native";
 import { PatternItemTypes } from "./constants";
-
 class HMSPolygonView extends Component {
   constructor() {
     super();
@@ -37,15 +45,15 @@ HMSPolygonView.propTypes = {
     exact({
       latitude: number.isRequired,
       longitude: number.isRequired,
-    }),
+    })
   ),
   holes: arrayOf(
     arrayOf(
       exact({
         latitude: number.isRequired,
         longitude: number.isRequired,
-      }),
-    ),
+      })
+    )
   ),
   clickable: bool,
   fillColor: oneOfType([number, arrayOf(number)]),
@@ -57,7 +65,7 @@ HMSPolygonView.propTypes = {
     exact({
       type: oneOf(Object.values(PatternItemTypes)).isRequired,
       length: number,
-    }).isRequired,
+    }).isRequired
   ),
   visible: bool,
   zIndex: number,
@@ -66,7 +74,7 @@ HMSPolygonView.propTypes = {
 
 const RNHMSPolygonView = requireNativeComponent(
   "HMSPolygonView",
-  HMSPolygonView,
+  HMSPolygonView
 );
 
 export default HMSPolygonView;

--- a/react-native-hms-map/src/PolylineView.js
+++ b/react-native-hms-map/src/PolylineView.js
@@ -14,11 +14,20 @@
     limitations under the License.
 */
 
-import { string, exact, oneOf, number, arrayOf, bool, func, oneOfType } from "prop-types";
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
+import {
+  arrayOf,
+  bool,
+  exact,
+  func,
+  number,
+  oneOf,
+  oneOfType,
+  string,
+} from "prop-types";
 import React, { Component } from "react";
-import { requireNativeComponent, ViewPropTypes } from "react-native";
-import { PatternItemTypes, CapTypes, JointTypes } from "./constants";
-
+import { requireNativeComponent } from "react-native";
+import { CapTypes, JointTypes, PatternItemTypes } from "./constants";
 class HMSPolylineView extends Component {
   constructor() {
     super();
@@ -40,7 +49,7 @@ HMSPolylineView.propTypes = {
     exact({
       latitude: number.isRequired,
       longitude: number.isRequired,
-    }),
+    })
   ),
   clickable: bool,
   geodesic: bool,
@@ -50,7 +59,7 @@ HMSPolylineView.propTypes = {
     exact({
       type: oneOf(Object.values(PatternItemTypes)).isRequired,
       length: number,
-    }),
+    })
   ),
   startCap: exact({
     type: oneOf(Object.values(CapTypes)).isRequired,
@@ -78,7 +87,7 @@ HMSPolylineView.propTypes = {
 
 const RNHMSPolylineView = requireNativeComponent(
   "HMSPolylineView",
-  HMSPolylineView,
+  HMSPolylineView
 );
 
 export default HMSPolylineView;

--- a/react-native-hms-map/src/TileOverlayView.js
+++ b/react-native-hms-map/src/TileOverlayView.js
@@ -14,10 +14,14 @@
     limitations under the License.
 */
 
-import { number, bool, exact, string, oneOfType, arrayOf } from 'prop-types';
-import React, { Component } from 'react';
-import { findNodeHandle, requireNativeComponent, UIManager, ViewPropTypes } from 'react-native';
-
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
+import { arrayOf, bool, exact, number, oneOfType, string } from "prop-types";
+import React, { Component } from "react";
+import {
+  findNodeHandle,
+  requireNativeComponent,
+  UIManager,
+} from "react-native";
 class HMSTileOverlayView extends Component {
   constructor() {
     super();
@@ -26,13 +30,19 @@ class HMSTileOverlayView extends Component {
   clearTileCache = () => {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.tileOverlayView),
-      UIManager.getViewManagerConfig('HMSTileOverlayView').Commands.clearTileCache,
+      UIManager.getViewManagerConfig("HMSTileOverlayView").Commands
+        .clearTileCache,
       null
     );
   };
 
   render() {
-    return <RNHMSTileOverlayView {...this.props} ref={(el) => (this.tileOverlayView = el)} />;
+    return (
+      <RNHMSTileOverlayView
+        {...this.props}
+        ref={(el) => (this.tileOverlayView = el)}
+      />
+    );
   }
 }
 
@@ -62,6 +72,9 @@ HMSTileOverlayView.propTypes = {
   zIndex: number,
 };
 
-const RNHMSTileOverlayView = requireNativeComponent('HMSTileOverlayView', HMSTileOverlayView);
+const RNHMSTileOverlayView = requireNativeComponent(
+  "HMSTileOverlayView",
+  HMSTileOverlayView
+);
 
 export default HMSTileOverlayView;


### PR DESCRIPTION
In version react-native above 0.68 Facebook deleted ViewPropTypes from react-native. I add deprecated-react-native-prop-types package dependency and tested it in  "react-native": "0.69.3" and that's work