### PR TITLE
Fix types and crash issue in ios for react-native-hms-availability

### DIFF
--- a/react-native-hms-availability/src/Availability.js
+++ b/react-native-hms-availability/src/Availability.js
@@ -15,18 +15,19 @@
 */
 
 import {NativeModules, Platform, NativeEventEmitter} from "react-native";
-const {HMSAvailabilityModule} = NativeModules;
+
+const isAndroid = Platform.OS === "android";
+const HMSAvailabilityModule = isAndroid ? NativeModules.HMSAvailabilityModule : {};
 
 class HMSAvailability {
 
-     static eventEmitter = new NativeEventEmitter(HMSAvailabilityModule)
-     static event = null;
- 
+    static event = null;
+
     static OnErrorDialogFragmentCancelledListenerAdd(handler){
         if(this.event == null){
-            this.event = this.eventEmitter.addListener('OnErrorDialogFragmentCancelled', handler); 
+            this.event = new NativeEventEmitter(HMSAvailabilityModule).addListener('OnErrorDialogFragmentCancelled', handler);
         }
-       }
+    }
 
     static OnErrorDialogFragmentCancelledListenerRemove(handler){
        this.event.remove();

--- a/react-native-hms-availability/src/index.d.ts
+++ b/react-native-hms-availability/src/index.d.ts
@@ -17,12 +17,12 @@ declare module "@hmscore/react-native-hms-availability" {
 
   
   export enum ErrorCode {
-    HMS_CORE_APK_AVAILABLE = "0",
-    NO_HMS_CORE_APK = "1",
-    HMS_CORE_APK_OUT_OF_DATE = "2",
-    HMS_CORE_APK_UNAVAILABLE = "3",
-    HMS_CORE_APK_IS_NOT_OFFICIAL_VERSION = "9",
-    HMS_CORE_APK_TOO_OLD = "21",
+    HMS_CORE_APK_AVAILABLE = 0,
+    NO_HMS_CORE_APK = 1,
+    HMS_CORE_APK_OUT_OF_DATE = 2,
+    HMS_CORE_APK_UNAVAILABLE = 3,
+    HMS_CORE_APK_IS_NOT_OFFICIAL_VERSION = 9,
+    HMS_CORE_APK_TOO_OLD = 21,
   }
 
   export interface ApiMap {
@@ -36,77 +36,77 @@ declare module "@hmscore/react-native-hms-availability" {
     'HuaweiPush.API': number
   }
   
-  export class HMSAvailability{
+  export default class HMSAvailability{
 
     /**
      * Obtains the API verssion number of each service.
      */
-    getApiMap(): Promise<ApiMap>;
+    static getApiMap(): Promise<ApiMap>;
 
     /**
      * Obtains the minimum version number of HMS Core that is supported currently.
      */
-    getServicesVersionCode(): Promise<number>;
+    static getServicesVersionCode(): Promise<number>;
 
     
     /**
      * Displays a readable text result code returned by the isHuaweiMobileServicesAvailable
      * (minApkVersion?: number) method.
      */
-    getErrorString(errorCode: number): Promise<string>;
+    static getErrorString(errorCode: number): Promise<string>;
 
     /**
      * Checks whether HMS Core (APK) is successfully installed and integrated on a device, 
      * and whether the version of the installed APK is that required by the client or is later 
      * than the required version.
      */
-    isHuaweiMobileServicesAvailable(minApkVersion?: number): Promise<number>;
+    static isHuaweiMobileServicesAvailable(minApkVersion?: number): Promise<number>;
 
     /**
      * Checks whether the HMS Core (APK) version supports notice obtaining.
      */
-    isHuaweiMobileNoticeAvailable(): Promise<number>;
+    static isHuaweiMobileNoticeAvailable(): Promise<number>;
 
     /**
      * Checks whether an exception is rectified through user operations.
      */
-    isUserResolvableError(errorCode: number): Promise<boolean>; 
+    static isUserResolvableError(errorCode: number): Promise<boolean>; 
 
     
     /**
      * Displays a notification or dialog box is displayed for the returned result code if
      * an exception can be rectified through user operations.
      */
-    resolveError(errorCode: number, requestCode: number): Promise<void>;
+    static resolveError(errorCode: number, requestCode: number): Promise<void>;
 
     
     /**
      * Sets the minimum version number of HMS Core that is supported currently.
      */
-    setServicesVersionCode(servicesVersionCode: number): Promise<void>;
+    static setServicesVersionCode(servicesVersionCode: number): Promise<void>;
     
     /**
      * Creates and displays a dialog box for a result code.
      */
-    showErrorDialogFragment(errorCode: number, requestCode: number): Promise<boolean>;
+    static showErrorDialogFragment(errorCode: number, requestCode: number): Promise<boolean>;
 
     
     /**
      * Creates and displays a dialog box for a result code.
      */
-    showErrorNotification(errorCode: number): Promise<void>;
+    static showErrorNotification(errorCode: number): Promise<void>;
 
     
     /**
      * Add a listener for the event when dialog fragment cancelled.
      */
-    OnErrorDialogFragmentCancelledListenerAdd(listenerFn: () => void): void;
+    static OnErrorDialogFragmentCancelledListenerAdd(listenerFn: () => void): void;
 
     
     /**
     * Remove the listener for the event when dialog fragment cancelled.
      */
-    OnErrorDialogFragmentCancelledListenerRemove(): void;
+    static OnErrorDialogFragmentCancelledListenerRemove(): void;
 
   }
 


### PR DESCRIPTION
Hi! When we import react-native-hms-availability, there is no issue in android or Huawei phones, but the app crashes if we run it on ios device.
The error is `Invariant Violation: new NativeEventEmitter() requires a non-null argument.`
The fix is to move `new NativeEventEmitter(HMSAvailabilityModule)` into `OnErrorDialogFragmentCancelledListenerAdd` function.