### PR TITLE
ADD react-native-hms-map setAccessToken function and made apiKey optional

### DIFF
--- a/react-native-hms-map/android/src/main/java/com/huawei/hms/rn/map/HMSMapView.java
+++ b/react-native-hms-map/android/src/main/java/com/huawei/hms/rn/map/HMSMapView.java
@@ -1411,13 +1411,18 @@ public class HMSMapView extends MapView implements UriIconView, OnMapReadyCallba
         }
 
         @ReactMethod
-        public void initializer(final String apiKey, final String routePolicy, final Promise promise) {
+        public void initializer(final String apiKey, final String routePolicy, final String accessToken, final Promise promise) {
             if (routePolicy != null && !routePolicy.isEmpty()) {
                 MapsInitializer.initialize(context, routePolicy);
             } else {
                 MapsInitializer.initialize(context);
             }
-            MapsInitializer.setApiKey(apiKey);
+            if (setAccessToken != null && !setAccessToken.isEmpty()) {
+                MapsInitializer.setAccessToken(accessToken);
+            }
+            if (apiKey != null && !apiKey.isEmpty()) {
+                MapsInitializer.setApiKey(apiKey);
+            }
             promise.resolve(null);
         }
 

--- a/react-native-hms-map/src/index.d.ts
+++ b/react-native-hms-map/src/index.d.ts
@@ -1619,9 +1619,16 @@ declare module "@hmscore/react-native-hms-map" {
 
     /**
      *  Initializes the Map SDK. You can set the data routing location. The options for routePolicy are CN (China), DE (Germany), SG (Singapore), and RU (Russia).
-     *  Sets the access token of the Map SDK.
+     *  Sets the apiKey or accessToken of the Map SDK.
+     *  apiKey does not need to be specified if the api_key field in the agconnect-services.json file already specifies an API key.
+     *  If its set its takes precedence.
+     *  If accessToken and apiKey set both, accessToken will be used for authentication
      */
-    initializer(apiKey: String, routePolicy: String): Promise<void>;
+    initializer(
+      apiKey?: String,
+      routePolicy?: "CN" | "DE" | "SG" | "RU",
+      accessToken?: String
+    ): Promise<void>;
 
     /**
      *  Obtains all attributes of the Huawei map object


### PR DESCRIPTION
According to [Huawei Map SDK](https://developer.huawei.com/consumer/en/doc/HMSCore-References/mapsinitializer-0000001050150366) apiKey is not required and initializer code block couldn't set AccessToken.

I had confusion about those terms and i set up wrongfully

https://github.com/HMS-Core/hms-react-native-plugin/issues/337

